### PR TITLE
Change Qualification.when to be a date.

### DIFF
--- a/specification.md
+++ b/specification.md
@@ -393,17 +393,26 @@ See paragraph 5.1 of [WCA Competition Requirements Policy](https://www.worldcube
 
 | Attribute | Type | Description |
 | --- | --- | --- |
-| `when` | [`DateTime`](#datetime) | The point in time at which the qualification requirement must be satisfied. |
-| `type` | `"single"\|"average"` | The type of result the requirement refers to. |
-| `attemptResult` | [`AttemptResult`](#attemptresult) | The attempt result that needs to be beaten in order to qualify to register for the event. |
+| `whenDate` | [`Date`](#date) | The date by which the qualification requirement must be satisfied.  If a result is set in a multiple-day competition which begins by this date, that is considered to have been set by this date. |
+| `type` | `"single"\|"average"\|"ranking"` | The type of result the requirement refers to. |
+| `attemptResult` | [`AttemptResult`](#attemptresult)\|`null` | The attempt result that needs to be beaten in order to qualify to register for the event. Required if `type` is "single" or "average". |
+| `ranking` | `Integer\|null` | The number of competitors to qualify for this event. Required if `type` is "ranking". |
 
-#### Example
+#### Examples
 
 ```json
 {
-  "when": "2020-04-25T6:00Z",
+  "whenDate": "2020-04-25",
   "type": "single",
   "attemptResult": 6000
+}
+```
+
+```json
+{
+  "whenDate": "2020-04-25",
+  "type": "ranking",
+  "ranking": 50
 }
 ```
 

--- a/specification.md
+++ b/specification.md
@@ -395,7 +395,7 @@ See paragraph 5.1 of [WCA Competition Requirements Policy](https://www.worldcube
 | --- | --- | --- |
 | `whenDate` | [`Date`](#date) | The date by which the qualification requirement must be satisfied.  If a result is set in a multiple-day competition which begins by this date, that is considered to have been set by this date. |
 | `type` | `"single"\|"average"\|"ranking"` | The type of result the requirement refers to. |
-| `level` | [`AttemptResult`](#attemptresult)\|`Integer`\|null | The parameter of the qualification condition of the given type. |
+| `level` | [`AttemptResult`](#attemptresult)\|[`Ranking`](#ranking) | The parameter of the qualification condition of the given type. |
 
 #### Examples
 

--- a/specification.md
+++ b/specification.md
@@ -395,8 +395,7 @@ See paragraph 5.1 of [WCA Competition Requirements Policy](https://www.worldcube
 | --- | --- | --- |
 | `whenDate` | [`Date`](#date) | The date by which the qualification requirement must be satisfied.  If a result is set in a multiple-day competition which begins by this date, that is considered to have been set by this date. |
 | `type` | `"single"\|"average"\|"ranking"` | The type of result the requirement refers to. |
-| `attemptResult` | [`AttemptResult`](#attemptresult)\|`null` | The attempt result that needs to be beaten in order to qualify to register for the event. Required if `type` is "single" or "average". |
-| `ranking` | `Integer\|null` | The number of competitors to qualify for this event. Required if `type` is "ranking". |
+| `level` | [`AttemptResult`](#attemptresult)\|`Integer`\|null | The parameter of the qualification condition of the given type. |
 
 #### Examples
 
@@ -404,7 +403,7 @@ See paragraph 5.1 of [WCA Competition Requirements Policy](https://www.worldcube
 {
   "whenDate": "2020-04-25",
   "type": "single",
-  "attemptResult": 6000
+  "level": 6000
 }
 ```
 
@@ -412,7 +411,7 @@ See paragraph 5.1 of [WCA Competition Requirements Policy](https://www.worldcube
 {
   "whenDate": "2020-04-25",
   "type": "ranking",
-  "ranking": 50
+  "level": 50
 }
 ```
 


### PR DESCRIPTION
This is for thewca/worldcubeassociation.org#2051.  Basing a qualification result on a DateTime is more precision than we can really measure -- we don't know at what time during a competition a result was set.  The best we can say for sure is whether the competition start_date or end_date was before the qualification results were due.  I defined this based on start_date to not disincentivize multi-day competitions, though end_date could as easily be used.

In addition, change the name of `when` to `whenDate`, in compliance with the style guide.

Because Qualification is not implemented currently in the WCA website, I hope that changing the definition is safe.