### PR TITLE
Clarify how ranking Qualifications are selected.

### DIFF
--- a/specification.md
+++ b/specification.md
@@ -395,15 +395,17 @@ See paragraph 5.1 of [WCA Competition Requirements Policy](https://www.worldcube
 | Attribute | Type | Description |
 | --- | --- | --- |
 | `whenDate` | [`Date`](#date) | The date by which the qualification requirement must be satisfied.  If a result is set in a multiple-day competition which begins by this date, that is considered to have been set by this date. |
-| `type` | `"single"\|"average"\|"ranking"` | The type of result the requirement refers to. |
-| `level` | [`AttemptResult`](#attemptresult)\|[`Ranking`](#ranking) | The parameter of the qualification condition of the given type. |
+| `type` | `"attemptResult"\|"ranking"\|"anyResult"` | The type of Qualification standard. |
+| `resultType` | `"single"\|"average"` | The type of result the requirement refers to. |
+| `level` | [`AttemptResult`](#attemptresult)\|[`Ranking`](#ranking)\|`null` | The parameter of the qualification condition of the given type. Not used with `anyResult`. |
 
 #### Examples
 
 ```json
 {
   "whenDate": "2020-04-25",
-  "type": "single",
+  "type": "attemptResult",
+  "resultType": "single",
   "level": 6000
 }
 ```
@@ -412,7 +414,17 @@ See paragraph 5.1 of [WCA Competition Requirements Policy](https://www.worldcube
 {
   "whenDate": "2020-04-25",
   "type": "ranking",
+  "resultType": "average",
   "level": 50
+}
+```
+
+```json
+{
+  "whenDate": "2020-04-25",
+  "type": "anyResult",
+  "resultType": "single",
+  "level": null
 }
 ```
 

--- a/specification.md
+++ b/specification.md
@@ -395,7 +395,7 @@ See paragraph 5.1 of [WCA Competition Requirements Policy](https://www.worldcube
 | Attribute | Type | Description |
 | --- | --- | --- |
 | `whenDate` | [`Date`](#date) | The date by which the qualification requirement must be satisfied.  If a result is set in a multiple-day competition which begins by this date, that is considered to have been set by this date. |
-| `type` | `"attemptResult"\|"ranking"\|"anyResult"` | The type of Qualification standard. |
+| `type` | `"attemptResult"\|"ranking"\|"anyResult"` | The type of qualification. Either of ranking (top N competitors), attempt result (competitors with result better than Y - either single or average) or any result (competitors with any successful result of the given type). |
 | `resultType` | `"single"\|"average"` | The type of result the requirement refers to. |
 | `level` | [`AttemptResult`](#attemptresult)\|[`Ranking`](#ranking)\|`null` | The parameter of the qualification condition of the given type. Not used with `anyResult`. |
 


### PR DESCRIPTION
The current spec does not distinguish between "Top N average" and "Top N single". Some competitions use average while others use single for events like 333fm.

Related to thewca/worldcubeassociation.org#2051.