### PR TITLE
updated the description of AdvancementCondition[percent]

### DIFF
--- a/specification.md
+++ b/specification.md
@@ -385,7 +385,7 @@ An `Integer` number of competitors.
 
 ### Percent
 
-An `Integer` (between 0 and 100, inclusive) representing a percent of competitors (rounded down to the nearest integer).
+An `Integer` (between 0 and 75, inclusive, per [regulation 9p1](https://www.worldcubeassociation.org/regulations/#9p1)) representing a percentage of competitors (rounded down to the nearest integer) who will advance to the next round.
 
 ### AttemptResult
 


### PR DESCRIPTION
I noticed that the allowed range for the "percent" subkey of AdvancementCondition (an Integer between 0 and 100 inclusive) was inconsistent with regulation 9p1, "At least 25% of competitors must be eliminated between consecutive rounds of the same event." The range should be 0 to 75, inclusive.

This pull request implements that and makes other clarifying edits to the description of the "percent" subkey.

Background: This is Jason Black, 2019BLAC02. I have been working with Cailyn Hoover to get more involved with tools for comp organizers, and she suggested a good place to start would be by improving the WCIF docs. This pull request is just to say hello and dip my toe in those waters before engaging in any substantive edits.