### PR TITLE
Add Location and RegistrationInfo objects to root

### DIFF
--- a/specification.md
+++ b/specification.md
@@ -19,6 +19,7 @@ The specification defines the following types:
 - [Avatar](#Avatar)
 - [Competition](#Competition)
 - [CountryCode](#CountryCode)
+- [CurrencyCode](#CurrencyCode)
 - [Cutoff](#Cutoff)
 - [Date](#Date)
 - [DateTime](#DateTime)
@@ -31,6 +32,7 @@ The specification defines the following types:
 - [Qualification](#Qualification)
 - [Ranking](#Ranking)
 - [Registration](#Registration)
+- [RegistrationInfo](#RegistrationInfo)
 - [Result](#Result)
 - [Role](#Role)
 - [Room](#Room)
@@ -57,6 +59,7 @@ Represents the root object and is usually referred to as a WCIF.
 | `events` | [`[Event]`](#event) | List of all events held at the competition. |
 | `schedule` | [`Schedule`](#schedule) | All the data related to time and scheduling. |
 | `location` | [`Location`](#location) | Data related to the competition's assigned location. |
+| `registrationInfo` | [`RegistrationInfo`](#registrationinfo) | Data related to when and how competitors can register for the competition. |
 | `competitorLimit` | `Integer\|null` | The maximal number of competitors that can register for the competition. |
 | `extensions` | [`[Extension]`](#extension) | List of custom competition extensions. |
 
@@ -153,6 +156,16 @@ A `String` representing the [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/I
 US
 ```
 
+### CurrencyCode
+
+A `String` representing the [ISO 4217](https://en.wikipedia.org/wiki/ISO_4217) code of the given currency.
+
+#### Example
+
+```json
+CAD
+```
+
 ### Role
 
 A `String` representing a role at the competition.
@@ -195,6 +208,28 @@ Represents person registration data.
   "comments": "I would like to opt-in for the pizza.",
   "administrativeNotes": "Emailed competitor on 05/08 to verify their date of birth",
   "isCompeting": true
+}
+```
+
+### RegistrationInfo
+
+Represents information related to when and how to register for the competition.
+
+| Attribute | Type | Description |
+| --- | --- | --- |
+| `registrationOpen` | [`DateTime`](#datetime) | The point in time when online registration opens. |
+| `registrationClose` | [`DateTime`](#datetime) | The point in time when online registration closes. |
+| `baseEntryFee` | `Integer` | The competition's base fee for online registration. |
+| `currencyCode` | [`CurrencyCode`](#currencycode) | The currency of the `baseEntryFee`. |
+
+#### Example
+
+```json
+{
+  "registrationOpen": "2023-08-29T05:00:00Z",
+  "registrationClose": "2023-10-13T06:00:00Z",
+  "baseEntryFee": 20,
+  "currencyCode": "USD"
 }
 ```
 

--- a/specification.md
+++ b/specification.md
@@ -153,7 +153,7 @@ A `String` representing the [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/I
 #### Example
 
 ```json
-US
+"US"
 ```
 
 ### CurrencyCode
@@ -163,7 +163,7 @@ A `String` representing the [ISO 4217](https://en.wikipedia.org/wiki/ISO_4217) c
 #### Example
 
 ```json
-CAD
+"CAD"
 ```
 
 ### Role

--- a/specification.md
+++ b/specification.md
@@ -24,6 +24,7 @@ The specification defines the following types:
 - [DateTime](#DateTime)
 - [Event](#Event)
 - [Extension](#Extension)
+- [Location](#Location)
 - [Percent](#Percent)
 - [Person](#Person)
 - [PersonalBest](#PersonalBest)
@@ -55,6 +56,7 @@ Represents the root object and is usually referred to as a WCIF.
 | `persons` | [`[Person]`](#person) | List of all the people related to the competition. |
 | `events` | [`[Event]`](#event) | List of all events held at the competition. |
 | `schedule` | [`Schedule`](#schedule) | All the data related to time and scheduling. |
+| `location` | [`Location`](#location) | Data related to the competition's assigned location. |
 | `competitorLimit` | `Integer\|null` | The maximal number of competitors that can register for the competition. |
 | `extensions` | [`[Extension]`](#extension) | List of custom competition extensions. |
 
@@ -553,6 +555,32 @@ Represents the competition data related to time and scheduling.
   "startDate": "2020-06-12",
   "numberOfDays": 2,
   "venues": [...]
+}
+```
+
+### Location
+
+Represents the main location assigned to a competition. The `Location` may contain some data that overlaps with a competition [`Venue`](#Venue), but it is possible that no competition `Venue` contains the exact same data as the `Location` (e.g., for 3x3x3 Fewest Moves simultaneous competitions). Only the `Location` contains the `city` and `address`.
+
+| Attribute | Type | Description |
+| --- | --- | --- |
+| `name` | `String` | The name of the competition venue. |
+| `address` | `String` | The address of the competition venue. |
+| `city` | `String` | The city where the competition is located. |
+| `countryIso2` | [`CountryCode`](#countrycode) | The country where the competition is located. |
+| `latitudeMicrodegrees` | `Integer` | The geographic latitude of the competition in microdegrees (degrees times 10^6). |
+| `longitudeMicrodegrees` | `Integer` | The geographic longitude of the competition in microdegrees (degrees times 10^6). |
+
+#### Example
+
+```json
+{
+  "name": "Westin Harbour Castle Conference Centre",
+  "address": "11 Bay Street, Toronto, Ontario",
+  "cityName": "Toronto, Ontario",
+  "countryIso2": "CA",
+  "latitudeMicrodegrees": 43641740,
+  "longitudeMicrodegrees": 79376902
 }
 ```
 


### PR DESCRIPTION
Closes #16.

Open to suggestions on the spec.

For `RegistrationInfo`, I decided to just include a subset of the fields stored in the website's `Competition` table that relate to registration. For example, I excluded `on_the_spot_registration` and `on_the_spot_entry_fee_lowest_denomination` since it wouldn't serve a purpose for https://github.com/Speedcubing-Canada/speedcubing-canada-web/issues/48. However, if we feel that a more exhaustive object would be better, I am happy to write the spec and include that in the PR to update the API. My opinion is that we should add fields if/when they become useful.

For `Location`, as mentioned in the object's spec, there _could_ be some overlap with `Venue`. However, I think it's good to include both in the export since the data is not guaranteed to be identical. The spec mentions 3x3x3 Fewest Moves simultaneous competitions, but there is also the possibility that, for example, `Location` points to the main entrance to a university campus and the one `Venue` points to a specific building.