### PR TITLE
Add RegistrationInfo to the competition.

### DIFF
--- a/specification.md
+++ b/specification.md
@@ -216,7 +216,7 @@ Represents information related to when and how to register for the competition.
 | --- | --- | --- |
 | `openTime` | [`DateTime`](#datetime) | The point in time when online registration opens. |
 | `closeTime` | [`DateTime`](#datetime) | The point in time when online registration closes. |
-| `baseEntryFeeiLowestDenomination` | `Integer` | The competition's base fee for online registration, in the lowest denomination of the specified currency code. |
+| `baseEntryFeeLowestDenomination` | `Integer` | The competition's base fee for online registration, in the lowest denomination of the specified currency code. |
 | `currencyCode` | [`CurrencyCode`](#currencycode) | The currency of the `baseEntryFee`, following ISO 4217. |
 | `onTheSpotRegistration` | `Boolean` | Whether non-registered competitors are permitted to sign up at the competition. |
 | `usesWcaRegistration` | `Boolean` | Whether registration takes place on the WCA website |

--- a/specification.md
+++ b/specification.md
@@ -216,9 +216,10 @@ Represents information related to when and how to register for the competition.
 | --- | --- | --- |
 | `openTime` | [`DateTime`](#datetime) | The point in time when online registration opens. |
 | `closeTime` | [`DateTime`](#datetime) | The point in time when online registration closes. |
-| `baseEntryFee` | `Integer` | The competition's base fee for online registration. |
-| `currencyCode` | [`CurrencyCode`](#currencycode) | The currency of the `baseEntryFee`. |
-| `onTheSpotRegistration` | `Boolean` | Whether non-registered competitors are permitted to sign up at the competition. +
+| `baseEntryFeeiLowestDenomination` | `Integer` | The competition's base fee for online registration, in the lowest denomination of the specified currency code. |
+| `currencyCode` | [`CurrencyCode`](#currencycode) | The currency of the `baseEntryFee`, following ISO 4217. |
+| `onTheSpotRegistration` | `Boolean` | Whether non-registered competitors are permitted to sign up at the competition. |
+| `usesWcaRegistration` | `Boolean` | Wthether registration takes place on the WCA website |
 
 #### Example
 
@@ -226,11 +227,14 @@ Represents information related to when and how to register for the competition.
 {
   "openTime": "2023-08-29T05:00:00Z",
   "closeTime": "2023-11-18T05:00:00Z",
-  "baseEntryFee": 20,
+  "baseEntryFeeLowestDenomination": 2000,
   "currencyCode": "USD",
   "onTheSpotRegistration": false,
+  "usesWcaRegistration": true,
 }
 ```
+
+In this example, the registration fee is $20.00 USD, because the lowest denomination of USD is cents ($0.01 USD).
 
 ### Avatar
 

--- a/specification.md
+++ b/specification.md
@@ -216,7 +216,7 @@ Represents information related to when and how to register for the competition.
 | --- | --- | --- |
 | `openTime` | [`DateTime`](#datetime) | The point in time when online registration opens. |
 | `closeTime` | [`DateTime`](#datetime) | The point in time when online registration closes. |
-| `baseEntryFeeLowestDenomination` | `Integer` | The competition's base fee for online registration, in the lowest denomination of the specified currency code. |
+| `baseEntryFeeIso` | `Integer` | The competition's base fee for online registration, in the lowest denomination of the specified currency code, following ISO 4217. |
 | `currencyCode` | [`CurrencyCode`](#currencycode) | The currency of the `baseEntryFee`, following ISO 4217. |
 | `onTheSpotRegistration` | `Boolean` | Whether non-registered competitors are permitted to sign up at the competition. |
 | `useWcaRegistration` | `Boolean` | Whether registration takes place on the WCA website. |
@@ -227,7 +227,7 @@ Represents information related to when and how to register for the competition.
 {
   "openTime": "2023-08-29T05:00:00Z",
   "closeTime": "2023-11-18T05:00:00Z",
-  "baseEntryFeeLowestDenomination": 2000,
+  "baseEntryFeeIso": 2000,
   "currencyCode": "USD",
   "onTheSpotRegistration": false,
   "useWcaRegistration": true,

--- a/specification.md
+++ b/specification.md
@@ -219,7 +219,7 @@ Represents information related to when and how to register for the competition.
 | `baseEntryFeeiLowestDenomination` | `Integer` | The competition's base fee for online registration, in the lowest denomination of the specified currency code. |
 | `currencyCode` | [`CurrencyCode`](#currencycode) | The currency of the `baseEntryFee`, following ISO 4217. |
 | `onTheSpotRegistration` | `Boolean` | Whether non-registered competitors are permitted to sign up at the competition. |
-| `usesWcaRegistration` | `Boolean` | Wthether registration takes place on the WCA website |
+| `usesWcaRegistration` | `Boolean` | Whether registration takes place on the WCA website |
 
 #### Example
 

--- a/specification.md
+++ b/specification.md
@@ -218,7 +218,6 @@ Represents information related to when and how to register for the competition.
 | `closeTime` | [`DateTime`](#datetime) | The point in time when online registration closes. |
 | `baseEntryFee` | `Integer` | The competition's base fee for online registration. |
 | `currencyCode` | [`CurrencyCode`](#currencycode) | The currency of the `baseEntryFee`. |
-| `competitorLimit` | `Integer` | The maximum number of competitors who can register for this competition. |
 | `onTheSpotRegistration` | `Boolean` | Whether non-registered competitors are permitted to sign up at the competition. +
 
 #### Example
@@ -229,7 +228,6 @@ Represents information related to when and how to register for the competition.
   "closeTime": "2023-11-18T05:00:00Z",
   "baseEntryFee": 20,
   "currencyCode": "USD",
-  "competitorLimit": 100,
   "onTheSpotRegistration": false,
 }
 ```

--- a/specification.md
+++ b/specification.md
@@ -73,6 +73,7 @@ Represents the root object and is usually referred to as a WCIF.
   "persons": [...],
   "events": [...],
   "schedule": {...},
+  "registrationInfo": [...],
   "competitorLimit": 1000,
   "extensions": [...]
 }

--- a/specification.md
+++ b/specification.md
@@ -230,7 +230,7 @@ Represents information related to when and how to register for the competition.
   "baseEntryFeeLowestDenomination": 2000,
   "currencyCode": "USD",
   "onTheSpotRegistration": false,
-  "usesWcaRegistration": true,
+  "useWcaRegistration": true,
 }
 ```
 

--- a/specification.md
+++ b/specification.md
@@ -219,7 +219,7 @@ Represents information related to when and how to register for the competition.
 | `baseEntryFee` | `Integer` | The competition's base fee for online registration. |
 | `currencyCode` | [`CurrencyCode`](#currencycode) | The currency of the `baseEntryFee`. |
 | `competitorLimit` | `Integer` | The maximum number of competitors who can register for this competition. |
-| `walkInsPermitted` | `Boolean` | Whether non-registered competitors are permitted to sign up at the competition. +
+| `onTheSpotRegistration` | `Boolean` | Whether non-registered competitors are permitted to sign up at the competition. +
 
 #### Example
 
@@ -230,7 +230,7 @@ Represents information related to when and how to register for the competition.
   "baseEntryFee": 20,
   "currencyCode": "USD",
   "competitorLimit": 100,
-  "walkInsPermitted": false,
+  "onTheSpotRegistration": false,
 }
 ```
 

--- a/specification.md
+++ b/specification.md
@@ -219,7 +219,7 @@ Represents information related to when and how to register for the competition.
 | `baseEntryFeeLowestDenomination` | `Integer` | The competition's base fee for online registration, in the lowest denomination of the specified currency code. |
 | `currencyCode` | [`CurrencyCode`](#currencycode) | The currency of the `baseEntryFee`, following ISO 4217. |
 | `onTheSpotRegistration` | `Boolean` | Whether non-registered competitors are permitted to sign up at the competition. |
-| `usesWcaRegistration` | `Boolean` | Whether registration takes place on the WCA website |
+| `useWcaRegistration` | `Boolean` | Whether registration takes place on the WCA website. |
 
 #### Example
 

--- a/specification.md
+++ b/specification.md
@@ -216,7 +216,7 @@ Represents information related to when and how to register for the competition.
 | --- | --- | --- |
 | `openTime` | [`DateTime`](#datetime) | The point in time when online registration opens. |
 | `closeTime` | [`DateTime`](#datetime) | The point in time when online registration closes. |
-| `baseEntryFeeIso` | `Integer` | The competition's base fee for online registration, in the lowest denomination of the specified currency code, following ISO 4217. |
+| `baseEntryFee` | `Integer` | The competition's base fee for online registration, in the lowest denomination of the specified currency code, following ISO 4217. |
 | `currencyCode` | [`CurrencyCode`](#currencycode) | The currency of the `baseEntryFee`, following ISO 4217. |
 | `onTheSpotRegistration` | `Boolean` | Whether non-registered competitors are permitted to sign up at the competition. |
 | `useWcaRegistration` | `Boolean` | Whether registration takes place on the WCA website. |
@@ -227,7 +227,7 @@ Represents information related to when and how to register for the competition.
 {
   "openTime": "2023-08-29T05:00:00Z",
   "closeTime": "2023-11-18T05:00:00Z",
-  "baseEntryFeeIso": 2000,
+  "baseEntryFee": 2000,
   "currencyCode": "USD",
   "onTheSpotRegistration": false,
   "useWcaRegistration": true,

--- a/specification.md
+++ b/specification.md
@@ -19,6 +19,7 @@ The specification defines the following types:
 - [Avatar](#Avatar)
 - [Competition](#Competition)
 - [CountryCode](#CountryCode)
+- [CurrencyCode](#CurrencyCode)
 - [Cutoff](#Cutoff)
 - [Date](#Date)
 - [DateTime](#DateTime)
@@ -30,6 +31,7 @@ The specification defines the following types:
 - [Qualification](#Qualification)
 - [Ranking](#Ranking)
 - [Registration](#Registration)
+- [RegistrationInfo](#RegistrationInfo)
 - [Result](#Result)
 - [Role](#Role)
 - [Room](#Room)
@@ -55,6 +57,7 @@ Represents the root object and is usually referred to as a WCIF.
 | `persons` | [`[Person]`](#person) | List of all the people related to the competition. |
 | `events` | [`[Event]`](#event) | List of all events held at the competition. |
 | `schedule` | [`Schedule`](#schedule) | All the data related to time and scheduling. |
+| `registrationInfo` | [`RegistrationInfo`] | All the data related to the competition's registration. |
 | `competitorLimit` | `Integer\|null` | The maximal number of competitors that can register for the competition. |
 | `extensions` | [`[Extension]`](#extension) | List of custom competition extensions. |
 
@@ -148,7 +151,17 @@ A `String` representing the [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/I
 #### Example
 
 ```json
-US
+"US"
+```
+
+### CurrencyCode
+
+A `String` representing the [ISO 4217](https://en.wikipedia.org/wiki/ISO_4217) code of the given currency.
+
+#### Example
+
+```json
+"CAD"
 ```
 
 ### Role
@@ -191,6 +204,32 @@ Represents person registration data.
   "guests": 2,
   "comments": "I would like to opt-in for the pizza.",
   "administrativeNotes": "Emailed competitor on 05/08 to verify their date of birth"
+}
+```
+
+### RegistrationInfo
+
+Represents information related to when and how to register for the competition.
+
+| Attribute | Type | Description |
+| --- | --- | --- |
+| `openTime` | [`DateTime`](#datetime) | The point in time when online registration opens. |
+| `closeTime` | [`DateTime`](#datetime) | The point in time when online registration closes. |
+| `baseEntryFee` | `Integer` | The competition's base fee for online registration. |
+| `currencyCode` | [`CurrencyCode`](#currencycode) | The currency of the `baseEntryFee`. |
+| `competitorLimit` | `Integer` | The maximum number of competitors who can register for this competition. |
+| `walkInsPermitted` | `Boolean` | Whether non-registered competitors are permitted to sign up at the competition. +
+
+#### Example
+
+```json
+{
+  "openTime": "2023-08-29T05:00:00Z",
+  "closeTime": "2023-11-18T05:00:00Z",
+  "baseEntryFee": 20,
+  "currencyCode": "USD",
+  "competitorLimit": 100,
+  "walkInsPermitted": false,
 }
 ```
 


### PR DESCRIPTION
Part of #16; stolen from @JonEsparaz's #17.

It's a bit awkward that competitorLimit is a property on the top-level WCIF. This adds a duplicate to registrationInfo, which is probably a better home for it, but I'm not sure how to safely(-ish) deprecate this. Thoughts?