### PR TITLE
Fix 2 mistakes in specs & update outdated info in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,4 @@ for people without a registration (e.g. non-participating organizer).
 
 ## Examples
 
-There are many applications using the WCIF format already, those include:
-- [WCA Live](https://github.com/thewca/wca-live)
-- [Groupifier](https://github.com/jonatanklosko/groupifier)
-- [Scrambles Matcher](https://github.com/viroulep/scrambles-matcher)
-- [TNoodle](https://github.com/thewca/tnoodle)
-- [WCIF Scripts](https://github.com/jonatanklosko/wcif-scripts)
+There are many applications using the WCIF format already. Those include the ones listed on the [Software tools page](https://www.worldcubeassociation.org/score-tools).

--- a/README.md
+++ b/README.md
@@ -33,4 +33,4 @@ for people without a registration (e.g. non-participating organizer).
 
 ## Examples
 
-There are many applications using the WCIF format already. Those include the ones listed on the [Software tools page](https://www.worldcubeassociation.org/score-tools).
+There are many applications using the WCIF format already. Those include the ones listed on the [Score tools page](https://www.worldcubeassociation.org/score-tools).

--- a/specification.md
+++ b/specification.md
@@ -403,7 +403,7 @@ Represents an attempt result the competitor needs to beat in one of the first ph
 | Attribute | Type | Description |
 | --- | --- | --- |
 | `numberOfAttempts` | `Integer` | The number of attempts the competitors has to get an attempt better than `attemptResult`. |
-| `attemptResult` | [`[AttemptResult]`](#attemptresult) | The attempt result that needs to be beaten in order to be eligible for the remaining attempts. |
+| `attemptResult` | [`AttemptResult`](#attemptresult) | The attempt result that needs to be beaten in order to be eligible for the remaining attempts. |
 
 #### Example
 
@@ -506,11 +506,11 @@ See paragraph 5.1 of [WCA Competition Requirements Policy](https://www.worldcube
 
 Represents a competitor result in a single round.
 
-| Attribute | Type | Description |
-| --- | --- | --- |
-| `personId` | `Integer` | The corresponding person `registrantId`. |
-| `ranking` | `Integer\|null` | The ranking in this round. May be `null` if the result is empty (yet to be entered). |
-| `attempts` | [`Attempt`](#attempt) | List of attempt results the competitor got. If there are fewer attempts than expected, the rest is considered skipped (effectively `0`). |
+| Attribute | Type                              | Description |
+| --- |-----------------------------------| --- |
+| `personId` | `Integer`                         | The corresponding person `registrantId`. |
+| `ranking` | `Integer\|null`                   | The ranking in this round. May be `null` if the result is empty (yet to be entered). |
+| `attempts` | [`[Attempt]`](#attempt)           | List of attempt results the competitor got. If there are fewer attempts than expected, the rest is considered skipped (effectively `0`). |
 | `best` | [`AttemptResult`](#attemptresult) | The best attempt result of `attempts`. |
 | `average` | [`AttemptResult`](#attemptresult) | The average attempt result of `attempts` (depending on the format, either average of 5 or mean of 3). |
 

--- a/specification.md
+++ b/specification.md
@@ -506,7 +506,7 @@ See paragraph 5.1 of [WCA Competition Requirements Policy](https://www.worldcube
 
 Represents a competitor result in a single round.
 
-| Attribute | Type                              | Description |
+| Attribute | Type | Description |
 | --- | --- | --- |
 | `personId` | `Integer` | The corresponding person `registrantId`. |
 | `ranking` | `Integer\|null` | The ranking in this round. May be `null` if the result is empty (yet to be entered). |

--- a/specification.md
+++ b/specification.md
@@ -507,10 +507,10 @@ See paragraph 5.1 of [WCA Competition Requirements Policy](https://www.worldcube
 Represents a competitor result in a single round.
 
 | Attribute | Type                              | Description |
-| --- |-----------------------------------| --- |
-| `personId` | `Integer`                         | The corresponding person `registrantId`. |
-| `ranking` | `Integer\|null`                   | The ranking in this round. May be `null` if the result is empty (yet to be entered). |
-| `attempts` | [`[Attempt]`](#attempt)           | List of attempt results the competitor got. If there are fewer attempts than expected, the rest is considered skipped (effectively `0`). |
+| --- | --- | --- |
+| `personId` | `Integer` | The corresponding person `registrantId`. |
+| `ranking` | `Integer\|null` | The ranking in this round. May be `null` if the result is empty (yet to be entered). |
+| `attempts` | [`[Attempt]`](#attempt) | List of attempt results the competitor got. If there are fewer attempts than expected, the rest is considered skipped (effectively `0`). |
 | `best` | [`AttemptResult`](#attemptresult) | The best attempt result of `attempts`. |
 | `average` | [`AttemptResult`](#attemptresult) | The average attempt result of `attempts` (depending on the format, either average of 5 or mean of 3). |
 


### PR DESCRIPTION
Fixed 1 mistake where the spec says Array of (...) but it is a single element
Fixed 1 mistake where it is the other way around

The README listed some apps that use the WCIF. This list was last updated in January 2020. I think it makes more sense to link to https://www.worldcubeassociation.org/score-tools , since the info of all apps there is more up-to-date