### PR TITLE
v2.2: Increment Patch version to add FTO and other minor changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The official specification of the [WCA Competition Interchange Format](./specifi
 
 ## Versioning
 
-This document is for v2.1.2, the current `latest` version of WCIF. See the following for more information:
+This document is for v2.2, the current `latest` version of WCIF. See the following for more information:
 - [Changelog](https://github.com/thewca/wcif/blob/latest/changelog.md) for more information.
 - [WCIF Versioning Policy](https://github.com/thewca/wcif/blob/latest/versioning-policy.md) for more information.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The official specification of the [WCA Competition Interchange Format](./specifi
 
 ## Versioning
 
-This document is for v2.1.1, the current `latest` version of WCIF. See the following for more information:
+This document is for v2.1.2, the current `latest` version of WCIF. See the following for more information:
 - [Changelog](https://github.com/thewca/wcif/blob/latest/changelog.md) for more information.
 - [WCIF Versioning Policy](https://github.com/thewca/wcif/blob/latest/versioning-policy.md) for more information.
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,10 @@
+## Changelog from v2.1.1
+
+### Minor
+- Added "Required Fields" section and marked `id` and `formatVersion` as required
+- `FTO` will be added to the list of event id's referenced in [Event](#Event)
+- Versioning policy updated to clarify that only major versions may be requested by version number
+
 ## v2.1.1: Change from v2.0.1
 
 ### Minor

--- a/changelog.md
+++ b/changelog.md
@@ -1,8 +1,10 @@
 ## Changelog from v2.1.1
 
 ### Minor
-- Added "Required Fields" section and marked `id` and `formatVersion` as required
 - `FTO` will be added to the list of event id's referenced in [Event](#Event)
+- Added "Required Fields" section and marked `id` and `formatVersion` as required
+
+### Patch
 - Versioning policy updated to clarify that only major versions may be requested by version number
 
 ## v2.1.1: Change from v2.0.1

--- a/changelog.md
+++ b/changelog.md
@@ -4,9 +4,6 @@
 - `FTO` will be added to the list of event id's referenced in [Event](#Event)
 - Added "Required Fields" section and marked `id` and `formatVersion` as required
 
-### Patch
-- Versioning policy updated to clarify that only major versions may be requested by version number
-
 ## v2.1.1: Change from v2.0.1
 
 ### Minor

--- a/specification.md
+++ b/specification.md
@@ -1,7 +1,7 @@
 # WCIF
 
 ## Version
-- Number: 2.1.1
+- Number: 2.1.2
 - Status: Latest
 - Next Status: Stable
 - Status Advancement Date: N/A
@@ -15,6 +15,11 @@ If you intend to read/write WCIF from the WCA website in your application, pleas
 - Familiarize yourself with the [WCIF Versioning Policy](https://github.com/thewca/wcif/blob/stable/versioning-policy.md)
 - [Sign up](https://www.worldcubeassociation.org/profile/edit?section=preferences) in your profile preferences to our developer mailing list to receive updates about new versions and deprecations.
 - Optionally, configure your application to monitor the `next_status` and `status_advancement_date` properties and alert you when these values change
+
+## Required Fields
+The following fields must be included in any WCIF payload - see [Competition](#Competition) for more details on these fields:
+- `id`
+- `formatVersion`
 
 ## Objects
 
@@ -61,8 +66,8 @@ Represents the root object and is usually referred to as a WCIF.
 
 | Attribute | Type | Description |
 | --- | --- | --- |
-| `formatVersion` | `String` | Used to distinguish different versions of the format (most notably compared to the past `0.3`). |
-| `id` | `String` | The unique competition identifier. |
+| `formatVersion` | `String` | Required field. Used to distinguish different versions of the format (most notably compared to the past `0.3`). |
+| `id` | `String` | Required field. The unique competition identifier. |
 | `name` | `String` | The full name of the competition. |
 | `shortName` | `String` | A briefer version of `name`, may be the same if `name` is already short. |
 | `series` | [`Series`](#series)\|`null` | The Competition Series that this competition is part of, if any. |

--- a/specification.md
+++ b/specification.md
@@ -1,7 +1,7 @@
 # WCIF
 
 ## Version
-- Number: 2.1.2
+- Number: 2.2
 - Status: Latest
 - Next Status: Stable
 - Status Advancement Date: N/A

--- a/versioning-policy.md
+++ b/versioning-policy.md
@@ -32,7 +32,7 @@ The existing WCIF endpoints will remain, and always serve the `stable` version o
 
 The following endpoints are not yet available, but will be implemented when we increment to v2.0 - this is expected in Q1 2026.
 - `api/v0/competitions/{competition-id}/wcif/{lifecycle-name}` to request the latest, or beta versions
--- `api/v0/competitions/{competition-id}/wcif/version/{version-number}` to request a specific version number
+- `api/v0/competitions/{competition-id}/wcif/version/{version-number}` to request a specific version number
 
 ## Backwards Compatibility  
 - In general, we aim to align with Google's [API-180](https://google.aip.dev/180) - feel free to raise concerns with us by opening a Github issue if you feel we deviate from this

--- a/versioning-policy.md
+++ b/versioning-policy.md
@@ -32,8 +32,7 @@ The existing WCIF endpoints will remain, and always serve the `stable` version o
 
 The following endpoints are not yet available, but will be implemented when we increment to v2.0 - this is expected in Q1 2026.
 - `api/v0/competitions/{competition-id}/wcif/{lifecycle-name}` to request the latest, or beta versions
--- `api/v0/competitions/{competition-id}/wcif/version/{major-version-number}` to request a specific major version number
-    - Note that only _major_ versions may be queried - `.../version/2` will return v2.x.y, and `.../version/2.1.1` will result in an error code. 
+-- `api/v0/competitions/{competition-id}/wcif/version/{version-number}` to request a specific version number
 
 ## Backwards Compatibility  
 - In general, we aim to align with Google's [API-180](https://google.aip.dev/180) - feel free to raise concerns with us by opening a Github issue if you feel we deviate from this

--- a/versioning-policy.md
+++ b/versioning-policy.md
@@ -32,7 +32,8 @@ The existing WCIF endpoints will remain, and always serve the `stable` version o
 
 The following endpoints are not yet available, but will be implemented when we increment to v2.0 - this is expected in Q1 2026.
 - `api/v0/competitions/{competition-id}/wcif/{lifecycle-name}` to request the latest, or beta versions
-- `api/v0/competitions/{competition-id}/wcif/version/{version-number}` to request a specific version number
+-- `api/v0/competitions/{competition-id}/wcif/version/{major-version-number}` to request a specific major version number
+    - Note that only _major_ versions may be queried - `.../version/2` will return v2.x.y, and `.../version/2.1.1` will result in an error code. 
 
 ## Backwards Compatibility  
 - In general, we aim to align with Google's [API-180](https://google.aip.dev/180) - feel free to raise concerns with us by opening a Github issue if you feel we deviate from this


### PR DESCRIPTION
## Changelog from v2.1.1

### Minor
- Added "Required Fields" section and marked `id` and `formatVersion` as required
- `FTO` will be added to the list of event id's referenced in [Event](#Event)
- Versioning policy updated to clarify that only major versions may be requested by version number